### PR TITLE
Update Clio sensor

### DIFF
--- a/components/template.yaml
+++ b/components/template.yaml
@@ -103,52 +103,46 @@
 
     - name: clio
       unique_id: clio
-      state: "{{ this.attributes.connexion in ['jl', 'valentine'] | default(false)}}"
+      state: "{{ this.attributes.driver_id != '-' | default(false)}}"
       attributes:
-        connexion: >
-          {% set jl_connected = namespace(value = false) -%}
-          {% set valentine_connected = namespace(value = false) -%}
-          {% set bt_mac_address = '04:4E:AF:AD:CA:B4' -%}
-          {% for device in state_attr('sensor.pixel_6_bluetooth_connection' , 'connected_paired_devices') -%}
-            {% if bt_mac_address in device -%}
-              {% set jl_connected.value = true -%}
-            {% endif -%}
-          {% endfor -%}
-          {% for device in state_attr('sensor.pixel_4a_bluetooth_connection' , 'connected_paired_devices') -%}
-            {% if bt_mac_address in device -%}
-              {% set valentine_connected.value = true -%}
-            {% endif -%}
-          {% endfor -%}
-          {% if jl_connected.value -%}
-            jl
-          {% elif valentine_connected.value -%}
-            valentine
-          {% else -%}
+        bluetooth_mac_adress: "00:00:00:00:00:00"
+        driver_id: >
+          {%- set value = "-" -%}
+          {%- for person in states.person -%}
+            {%- if state_attr("person."+person.attributes.id, "source") != None -%}
+              {%- if state_attr(state_attr("person."+person.attributes.id, "source") | replace("device_tracker", 'sensor') + "_bluetooth_connection", "connected_paired_devices") != None -%}
+                {%- for device in state_attr(state_attr("person."+person.attributes.id, "source") | replace("device_tracker", 'sensor') + "_bluetooth_connection", "connected_paired_devices") -%}
+                  {%- if this.attributes.bluetooth_mac_adress in device -%}
+                    {%- set value = state_attr("person."+person.attributes.id, "id") -%}
+                  {%- endif -%}
+                {%- endfor -%}
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{- value -}}
+        driver_name: >
+          {%- if this.attributes.driver_id != '-' -%}
+            {{ state_attr("person."+this.attributes.driver_id, "friendly_name") }}
+          {%- else -%}
             -
-          {% endif %}
+          {%- endif -%}
         latitude: >
-          {% if this.attributes.connexion == 'jl' -%}
-            {{state_attr('person.jenova70', 'latitude')}}
-          {% elif this.attributes.connexion == 'valentine' -%}
-            {{state_attr('person.valentine', 'latitude')}}
+          {%- if this.attributes.driver_id != '-' -%}
+            {{ state_attr("person."+this.attributes.driver_id, "latitude") }}
           {% else -%}
             {{ this.attributes.latitude | default(state_attr('zone.home', 'latitude')) }}
           {% endif -%}
         longitude: >
-          {% if this.attributes.connexion == 'jl' -%}
-            {{state_attr('person.jenova70', 'longitude')}}
-          {% elif this.attributes.connexion == 'valentine' -%}
-            {{state_attr('person.valentine', 'longitude')}}
+          {%- if this.attributes.driver_id != '-' -%}
+            {{ state_attr("person."+this.attributes.driver_id, "longitude") }}
           {% else -%}
             {{ this.attributes.longitude | default(state_attr('zone.home', 'longitude')) }}
           {% endif -%}
         gps_accuracy: >
-          {% if this.attributes.connexion == 'jl' -%}
-            {{state_attr('person.jenova70', 'gps_accuracy')}}
-          {% elif this.attributes.connexion == 'valentine' -%}
-            {{state_attr('person.valentine', 'gps_accuracy')}}
+          {%- if this.attributes.driver_id != '-' -%}
+            {{ state_attr("person."+this.attributes.driver_id, "gps_accuracy") }}
           {% else -%}
             {{ this.attributes.gps_accuracy | default(0) }}
-          {% endif -%}
+          {% endif -%}        
         entity_picture: "/local/clio.jpg"
         direction_url: "https://www.google.com/maps/dir/?api=1&destination={{ this.attributes.latitude | default(state_attr('zone.home', 'latitude'))}}%2C{{ this.attributes.longitude | default(state_attr('zone.home', 'longitude')) }}"


### PR DESCRIPTION
J'ai fais une modification à ton capteur Clio.

Avec cette modification, seul l'adresse mac doit être entrée manuellement dans le modèle. Ce dernier va automatiquement chercher les entités "person" présentes dans home assistant et regarde si une source "device_tracker" est présente. Si un "sensor" du même nom "sensor.xxxxx_bluetooth_connection" existe, le modèle fait les vérifications que tu as faites pour récupérer la position de la voiture.

Etant donné que je n'ai pas de téléphone android, je n'ai pas pu la tester 😔