### PR TITLE
Add old_state to until parameter

### DIFF
--- a/appdaemon/apps/notifier.py
+++ b/appdaemon/apps/notifier.py
@@ -2,13 +2,14 @@ import appdaemon.plugins.hass.hassapi as hass
 import math
 
 """
+Source : https://github.com/jlpouffier/home-assistant-config/blob/master/appdaemon/apps/notifier.py
  
 Notify is an app responsible for notifying the right occupant(s) at the right time, and making sure to discard notifications once they are not relevant anymore.
  
 Here is the list of parameter that you NEED to set in order to run the app:
 
 home_occupancy_sensor_id: the id of a binary sensor that will be true if someone is at home, and false otherwise
-proximity_threshold: A thresold in meter, bellow this threshold the app will concider the person at home. This is to avoid pinging only the first one that reaches Home if both occupant are on the same car for exmaple (Both will be pinged)
+proximity_threshold: A thresold in meter, bellow this threshold the app will concider the person at home. This is to avoid pinging only the first one that reaches Home if both occupant are on the same car for example (Both will be pinged)
 persons: A list of person, including
     name: their name
     id: the id of the person entity in home assistant

--- a/appdaemon/apps/notifier.py
+++ b/appdaemon/apps/notifier.py
@@ -146,25 +146,27 @@ class notifier(hass.Hass):
         self.log("NOTIFIER event received")  
         if "action" in data:
             action = data["action"]
-            for person in self.args["persons"]:
-                if action == "send_to_" + person["name"]:
-                    self.send_to_person(data, person)
-            if action == "send_to_all":
-                #send_to_all
-                self.send_to_all(data)
-            if action == "send_to_present":
-                #send_to_present
-                self.send_to_present(data)
-            if action == "send_to_absent":
-                #send_to_absent
-                self.send_to_absent(data)
-            if action == "send_to_nearest":
-                #send_to_nearest
-                self.send_to_nearest(data)
-            if action == "send_when_present":
-                #send_when_present
-                self.send_when_present(data) 
-        
+            match action:
+                case "send_to_all":
+                    # send_to_all
+                    self.send_to_all(data)
+                case "send_to_present":
+                    # send_to_present
+                    self.send_to_present(data)
+                case "send_to_absent":
+                    # send_to_absent
+                    self.send_to_absent(data)
+                case "send_to_nearest":
+                    # send_to_nearest
+                    self.send_to_nearest(data)
+                case "send_when_present":
+                    # send_when_present
+                    self.send_when_present(data)
+                case _:
+                    for person in self.args["persons"]:
+                        if action == "send_to_" + person["name"]:
+                            self.send_to_person(data, person)
+
         if "persistent" in data:
             if data["persistent"]:
                 if 'tag' in data:

--- a/appdaemon/apps/notifier.py
+++ b/appdaemon/apps/notifier.py
@@ -1,4 +1,4 @@
-import hassapi as hass
+import appdaemon.plugins.hass.hassapi as hass
 import math
 
 """


### PR DESCRIPTION
Bonjour Jean Loïc,

Voici une pull request pour notifier.py. 

- J'ai ajouté la possibilité de réagir sur le `old_state` dans la fonction `until`. Je m'en sert pour mon application de **gestion de liste de courses multiples**.  Ca me permet très simplement de supprimer un notification qui aurai "popée" lorsque je pase devant un magasin en voiture sans que je n'ai l'intention de rester dans la zone pour faire mes courses. Dès que je sors de la zone, `old_state` contient le nom de la zone qui a "trigger" la notification et elle est supprimée.
- J'ai aussi fait une petit optimisation sur le choix du type de notification à émettre.

Non proposé dans cette MR: j'ai mis en place un serie de tests automatiques pour toutes mes applications appdeamon (et donc y compris notifier.py) et c'est dispo [ici](https://github.com/XavierBerger/homeassistant-config/tree/main/appdaemon/test). Si ça t'intéresse, je veux bien t'expliquer ce que j'ai mis en place et comment ça marche.

Enfin pour terminer, je suis en train de publier mon application de gestion de liste de course sur le forum HACF.fr. Je vais bientôt publier un post dédié mais [ici](https://forum.hacf.fr/t/bonjour-moi-cest-x-v/27375/11) tu trouveras déjà un aperçu de ce que ça donne.

Merci pour tes partages

Xavier