### PR TITLE
Modify for Music Assistant 2.0 integration

### DIFF
--- a/blueprints/automation/perso/play_media_on_music_assistant.yaml
+++ b/blueprints/automation/perso/play_media_on_music_assistant.yaml
@@ -19,19 +19,18 @@ blueprint:
       default: "Play {query}"
       selector:
         text:
-    open_ai_config_entry:
-      name: OpenAI Configuration
-      description: The OpenAI configuration **configured with the prompt found [here](https://gist.github.com/jlpouffier/8d5dc8a6b94f42f4929bfd1df2f22008)**
+    conversation_agent:
+      name: Conversation Agent
+      description: The Conversation Agent configuration **configured with the prompt found [here](https://gist.github.com/jlpouffier/8d5dc8a6b94f42f4929bfd1df2f22008)**
       selector:
-        config_entry:
-          integration: "openai_conversation"
+        conversation_agent:
     media_player:
       name: Media player
       description: Media player that will play the music
       selector:
         entity:
           filter:
-            integration: "mass"
+            integration: "music_assistant"
             domain: "media_player"
     additional_conditions:
       name: Additional conditions
@@ -49,10 +48,10 @@ condition: !input additional_conditions
 action:
   - service: conversation.process
     data:
-      agent_id: !input open_ai_config_entry
+      agent_id: !input conversation_agent
       text: "{{trigger.slots.query}}"
     response_variable: response_from_ai
-  - service: mass.play_media
+  - service: music_assistant.play_media
     data: "{{response_from_ai.response.speech.plain.speech|from_json}}"
     target:
       entity_id: !input media_player


### PR DESCRIPTION
-  Replace `mass` integration with `music_assistant`
- Use a Conversation agent rather than specifically OpenAI config entry (allow for, e.g. Ollama)